### PR TITLE
Finish base feature set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E4", "E7", "E9", "F", 
-    "C", "W", "I", 
+    "C", "B", 
     "D1", "D201", "D202", "D205", "D210", "D212", "D4",
-    "B"
+    "E4", "E7", "E9", 
+    "F", "W",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/src/psycopg_async_notify/__main__.py
+++ b/src/psycopg_async_notify/__main__.py
@@ -1,31 +1,12 @@
 """Main execution entrypoint for application."""
 
-import argparse
-import asyncio
 import logging
 
-import psycopg
-
 from psycopg_async_notify.config import CONFIG
-from psycopg_async_notify.execute import listen_for_notifications
+from psycopg_async_notify.execute import config_run
 
 _log = logging.getLogger(__name__)
 
-
-def execute():
-    """Execute the application."""
-    parser = argparse.ArgumentParser(description="Listen for notifications on a channel.")
-    parser.add_argument("channel", help="The channel to listen for notifications on.")
-    args = parser.parse_args()
-
-    try:
-        asyncio.run(listen_for_notifications(args.channel, asyncio.Queue()))
-    except KeyboardInterrupt:
-        _log.debug("Exiting application")
-    except psycopg.OpertionalError as e:
-        _log.error("An error occurred: %s, disconnecting", e)
-
-
 if __name__ == "__main__":
     logging.basicConfig(level=CONFIG.log_level.upper())
-    execute()
+    config_run()

--- a/src/psycopg_async_notify/db.py
+++ b/src/psycopg_async_notify/db.py
@@ -36,18 +36,14 @@ async def get_connection(autocommit: bool = True) -> AsyncGenerator[psycopg.Asyn
 
 
 @asynccontextmanager
-async def get_cursor(
-    autocommit: bool = True, connection: psycopg.AsyncConnection = None
-) -> AsyncGenerator[psycopg.AsyncCursor, None]:
+async def get_cursor(autocommit: bool = True) -> AsyncGenerator[psycopg.AsyncCursor, None]:
     """Get a cursor context manager to the database.
 
     :param autocommit: whether to autocommit transactions
-    :param connection: an existing connection to use
     :return: a cursor to the database
     """
-    if connection is None:
-        async with get_connection(autocommit=autocommit) as conn:
-            async with conn.cursor() as cursor:
-                _log.debug("created cursor")
-                yield cursor
-                _log.debug("closing cursor")
+    async with get_connection(autocommit=autocommit) as conn:
+        async with conn.cursor() as cursor:
+            _log.debug("created cursor")
+            yield cursor
+            _log.debug("closing cursor")

--- a/src/psycopg_async_notify/publish.py
+++ b/src/psycopg_async_notify/publish.py
@@ -5,7 +5,6 @@ import json
 import logging
 import uuid
 
-from psycopg_async_notify import db
 from psycopg_async_notify.db import get_connection
 
 # Logger
@@ -18,7 +17,7 @@ async def publish_to_pg_notify(queue: asyncio.Queue, topic: str):
     :param queue: The queue to get messages from.
     """
     # Connect asycnronously to the PostgreSQL database
-    async with db.get_connection() as conn:
+    async with get_connection() as conn:
         async with conn.cursor() as cur:
             # Process messages from the queue
             # verify the PG NOTIFY channel exists is not, create it

--- a/src/test/mqtt_publish/test_mqtt_publish_config.py
+++ b/src/test/mqtt_publish/test_mqtt_publish_config.py
@@ -1,0 +1,11 @@
+"""Tests for mqtt_publish.config."""
+
+from mqtt_publish.config import CONFIG
+
+
+def test_config():
+    """Test dynaconf CONFIG."""
+    assert CONFIG.mqtt_broker
+
+    assert CONFIG.mqtt_broker.host == "localhost"
+    assert CONFIG.mqtt_broker.port == 1883

--- a/src/test/mqtt_publish/test_mqtt_publish_process.py
+++ b/src/test/mqtt_publish/test_mqtt_publish_process.py
@@ -1,0 +1,31 @@
+"""Tests for the process module of mqtt_publish."""
+
+from unittest import mock
+
+import pytest
+
+from mqtt_publish.process import publish_to_postgres
+
+
+@pytest.mark.asyncio
+async def test_publish_to_postgres():
+    """Test publish_to_postgres."""
+    m_topic = "test_topic"
+    m_broker = "localhost"
+
+    with (
+        mock.patch("mqtt_publish.process.setup_client", new_callable=mock.AsyncMock) as m_setup_client,
+        mock.patch(
+            "mqtt_publish.process.process_messages_to_queue", new_callable=mock.AsyncMock
+        ) as m_process_messages_to_queue,
+        mock.patch("mqtt_publish.process.publish_to_pg_notify", new_callable=mock.AsyncMock) as m_publish_to_pg_notify,
+    ):
+        await publish_to_postgres(m_broker, m_topic)
+
+        m_setup_client.assert_called_once_with(m_broker, m_topic, mock.ANY)
+        m_process_messages_to_queue.assert_called_once()
+        m_publish_to_pg_notify.assert_called_once()
+
+        m_setup_client.asssert_awaited_once()
+        m_process_messages_to_queue.asssert_awaited_once()
+        m_publish_to_pg_notify.asssert_awaited_once()

--- a/src/test/psycopg_async_notify/test_psycopg_async_config.py
+++ b/src/test/psycopg_async_notify/test_psycopg_async_config.py
@@ -1,0 +1,14 @@
+"""Tests for psycopg_async_notify.config."""
+
+from psycopg_async_notify.config import CONFIG
+
+
+def test_config():
+    """Test dynaconf CONFIG."""
+    assert CONFIG.database
+
+    assert CONFIG.database.host == "127.0.0.1"
+    assert CONFIG.database.port == 5432
+    assert isinstance(CONFIG.database.user, str)
+    assert isinstance(CONFIG.database.password, str)
+    assert isinstance(CONFIG.database.name, str)

--- a/src/test/psycopg_async_notify/test_psycopg_async_listen.py
+++ b/src/test/psycopg_async_notify/test_psycopg_async_listen.py
@@ -1,0 +1,29 @@
+"""Tests for the psycopg_async_notify.listen module."""
+
+import asyncio
+import logging
+from unittest import mock
+
+import pytest
+
+from psycopg_async_notify.listen import QueuePutNotifyHandler
+
+# Logger
+_log = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_queue_put_notify_handler():
+    """Test QueuePutNotifyHandler."""
+    m_notification = "test_payload"
+    m_queue = asyncio.Queue()
+    m_handler = QueuePutNotifyHandler(m_queue)
+
+    assert m_handler.queue is m_queue
+
+    m_notify = mock.Mock()
+    m_notify.payload = m_notification
+
+    m_handler.callback(m_notify)
+
+    assert await m_queue.get() == m_notification

--- a/src/test/psycopg_async_notify/test_psycopg_async_notify_db.py
+++ b/src/test/psycopg_async_notify/test_psycopg_async_notify_db.py
@@ -1,0 +1,61 @@
+"""Tests for the psycopg_async_notify.db module."""
+
+from unittest import mock
+
+import psycopg
+import pytest
+
+from psycopg_async_notify.config import CONFIG
+from psycopg_async_notify.db import get_connection, get_cursor
+
+
+@pytest.mark.asyncio
+async def test_get_connection():
+    """Test get_connection."""
+    with mock.patch("psycopg_async_notify.db.psycopg.AsyncConnection.connect") as m_connect:
+        m_connection = mock.AsyncMock()
+        m_connect.return_value = m_connection
+
+        async with get_connection() as conn:
+            assert conn is m_connection
+
+        m_connect.assert_called_once_with(
+            dbname=CONFIG.database.name,
+            user=CONFIG.database.user,
+            password=CONFIG.database.password,
+            host=CONFIG.database.host,
+            port=CONFIG.database.port,
+            autocommit=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_cursor():
+    """Test get_cursor."""
+    with mock.patch("psycopg_async_notify.db.get_connection") as m_get_connection:
+        # mock a connection and adde to the return value of the async
+        # context manager magic method (__aenter__) of m_get_connection
+        m_connection = mock.AsyncMock(spec=psycopg.AsyncConnection)
+
+        # doing a intermediate assignment for clarity
+        # this first line define m_connection equivalent to
+        # get_connection().__aenter__()
+        m_aenter_get_connection = m_get_connection.return_value.__aenter__
+        m_aenter_get_connection.return_value = m_connection
+
+        # mock a async cursor and add it to the return value of the async
+        # context manager magic method (__aenter__) of m_connection.cursor
+        m_cursor = mock.AsyncMock(spec=psycopg.AsyncCursor)
+        m_cursor.return_value.__aenter__.return_value = m_cursor
+
+        # define the return value of the async context manager magic method
+        # (__aenter__) of m_connection.cursor. equivalent relative to
+        # get_connection as:
+        # get_connection().__aenter__().cursor().__aenter__()
+        m_connection.cursor.return_value.__aenter__.return_value = m_cursor
+
+        async with get_cursor() as cursor:
+            assert cursor is m_cursor
+
+        m_get_connection.assert_called_once_with(autocommit=True)
+        m_connection.cursor.assert_called_once()

--- a/src/test/psycopg_async_notify/test_psycopg_async_notify_publish.py
+++ b/src/test/psycopg_async_notify/test_psycopg_async_notify_publish.py
@@ -1,0 +1,101 @@
+"""Tests for psycopg_async_notify.publish."""
+
+import asyncio
+from unittest import mock
+
+import aiomqtt
+import psycopg
+import pytest
+
+from psycopg_async_notify.publish import (help_send_notifcations_continuously,
+                                          help_send_notification,
+                                          publish_to_pg_notify)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_publish_to_pg_notify():
+    """Test publish_to_pg_notify."""
+    m_connection = mock.AsyncMock(spec=psycopg.AsyncConnection)
+    m_cursor = mock.AsyncMock(spec=psycopg.AsyncCursor)
+    m_topic = "test/test_publish_to_pg_notify"
+
+    with mock.patch("psycopg_async_notify.publish.get_connection", return_value=m_connection) as m_get_connection:
+        m_aenter_m_get_connection = m_get_connection.return_value.__aenter__
+        m_aenter_m_get_connection.return_value = m_connection
+
+        m_connection.cursor.return_value.__aenter__.return_value = m_cursor
+
+        m_queue = mock.AsyncMock(spec=asyncio.Queue)
+        m_queue.empty.return_value = False
+        m_queue.get.return_value = aiomqtt.Message(
+            topic=m_topic, payload=b"test_payload", qos=1, retain=False, mid=1, properties=None
+        )
+
+        publish_task = asyncio.create_task(publish_to_pg_notify(m_queue, m_topic))
+
+        await asyncio.sleep(0)
+
+        publish_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await publish_task
+
+        m_aenter_m_get_connection.assert_called_once()
+        m_connection.cursor.assert_called_once()
+        m_cursor.execute.assert_called()
+        m_queue.get.assert_called()
+
+
+async def test_help_send_notification():
+    """Test help_send_notification."""
+    m_connection = mock.AsyncMock(spec=psycopg.AsyncConnection)
+    m_channel = "test/test_help_send_notification"
+
+    with mock.patch("psycopg_async_notify.publish.get_connection", return_value=m_connection) as m_get_connection:
+        m_aenter_m_get_connection = m_get_connection.return_value.__aenter__
+        m_aenter_m_get_connection.return_value = m_connection
+
+        await help_send_notification(m_channel)
+
+        m_aenter_m_get_connection.assert_called_once()
+        m_connection.execute.assert_called()
+
+
+async def test_help_send_notifcations_continuously():
+    """Test help_send_notifcations_continuously."""
+    m_connection = mock.AsyncMock(spec=psycopg.AsyncConnection)
+    m_channel = "test/test_help_send_notifcations_continuously"
+
+    with mock.patch("psycopg_async_notify.publish.get_connection", return_value=m_connection) as m_get_connection:
+        m_aenter_m_get_connection = m_get_connection.return_value.__aenter__
+        m_aenter_m_get_connection.return_value = m_connection
+
+        send_notify_task = asyncio.create_task(help_send_notifcations_continuously(m_channel))
+
+        await asyncio.sleep(0)
+
+        send_notify_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await send_notify_task
+
+        m_aenter_m_get_connection.assert_called_once()
+        m_connection.execute.assert_called()
+
+
+async def test_help_send_notifications_continously_keyboard_interrupt():
+    """Test help_send_notifcations_continuously with KeyboardInterrupt."""
+    m_connection = mock.AsyncMock(spec=psycopg.AsyncConnection)
+    m_channel = "test/test_help_send_notifcations_continuously"
+
+    with mock.patch("psycopg_async_notify.publish.get_connection", return_value=m_connection) as m_get_connection:
+        m_aenter_m_get_connection = m_get_connection.return_value.__aenter__
+        m_aenter_m_get_connection.return_value = m_connection
+        m_connection.execute.side_effect = KeyboardInterrupt
+
+        with pytest.raises(KeyboardInterrupt):
+            await help_send_notifcations_continuously(m_channel)
+
+        m_aenter_m_get_connection.assert_called_once()
+        m_connection.execute.assert_called()


### PR DESCRIPTION
This pull request includes significant refactoring and the addition of new tests to the `psycopg_async_notify` and `mqtt_publish` modules. The main changes involve code reorganization, removal of redundant parameters, and comprehensive test coverage for various components.

### Refactoring and Code Reorganization:
* [`src/psycopg_async_notify/__main__.py`](diffhunk://#diff-10a6269c81fbfaccdc5cc3f2e2d85b8a0e2313fa29fe71fbd0826c7c4616dd22L3-R12): Replaced the `execute` function with `config_run` to streamline the main execution entry point.
* [`src/psycopg_async_notify/db.py`](diffhunk://#diff-1277c6cb05109a83908336c68cff99e569af81eb9ede2416ce33e796e9a10cc6L39-L48): Removed the `connection` parameter from the `get_cursor` function to simplify the cursor context manager.
* [`src/psycopg_async_notify/execute.py`](diffhunk://#diff-c40af2158e51c18312a4360effff2d53dd2bd184c8e1cb482d1f8b0feea03534R3-R8): Moved the argument parsing and application execution logic to a new `config_run` function. [[1]](diffhunk://#diff-c40af2158e51c18312a4360effff2d53dd2bd184c8e1cb482d1f8b0feea03534R3-R8) [[2]](diffhunk://#diff-c40af2158e51c18312a4360effff2d53dd2bd184c8e1cb482d1f8b0feea03534R40-R55)
* [`src/psycopg_async_notify/publish.py`](diffhunk://#diff-a9bf7de8c427bcf0ae6d1caf860ac492ee4d96f2083ac190de602399698a2017L8): Removed unnecessary import and updated the function call to use the simplified `get_connection`. [[1]](diffhunk://#diff-a9bf7de8c427bcf0ae6d1caf860ac492ee4d96f2083ac190de602399698a2017L8) [[2]](diffhunk://#diff-a9bf7de8c427bcf0ae6d1caf860ac492ee4d96f2083ac190de602399698a2017L21-R20)

### Test Coverage:
* Added new test files for `mqtt_publish` and `psycopg_async_notify` modules to ensure comprehensive test coverage:
  - [`src/test/mqtt_publish/test_mqtt_publish_config.py`](diffhunk://#diff-57d589440274cf5d2d250cb33ae0a520c4f50d8cc78d382cb8d1b2b9bb68d276R1-R11): Tests for the `mqtt_publish.config` module.
  - [`src/test/mqtt_publish/test_mqtt_publish_process.py`](diffhunk://#diff-761274d46f880fef62e0eebd3ce8920395e87158c8d68a5572476be0c3bf79faR1-R31): Tests for the process module of `mqtt_publish`.
  - [`src/test/psycopg_async_notify/test_psycopg_async_config.py`](diffhunk://#diff-817e81e25227bf5ce2ffb2db9556b95685f4c97496092f779e0736634c66e33bR1-R14): Tests for the `psycopg_async_notify.config` module.
  - [`src/test/psycopg_async_notify/test_psycopg_async_listen.py`](diffhunk://#diff-a9f28c3260a737dd007eda7ab3c02e37ce8029042932ded53fde3bebe7b2408bR1-R29): Tests for the `psycopg_async_notify.listen` module.
  - [`src/test/psycopg_async_notify/test_psycopg_async_notify.py`](diffhunk://#diff-4e273206461bb11c346dc71ed2eb39ef4e87582a13a6bea7fd1732eefffec19dL10-R10): Renamed from `test_execute.py` and added tests for `config_run` and notification listeners. [[1]](diffhunk://#diff-4e273206461bb11c346dc71ed2eb39ef4e87582a13a6bea7fd1732eefffec19dL10-R10) [[2]](diffhunk://#diff-4e273206461bb11c346dc71ed2eb39ef4e87582a13a6bea7fd1732eefffec19dR65-R89)
  - [`src/test/psycopg_async_notify/test_psycopg_async_notify_db.py`](diffhunk://#diff-46022de2a4af975260babb48e9e92306f4e850b3937a77f79b5da51aba577438R1-R61): Tests for the `psycopg_async_notify.db` module.
  - [`src/test/psycopg_async_notify/test_psycopg_async_notify_publish.py`](diffhunk://#diff-0b69894314973a3b3768672628957728e8ea3f45cd76976a7ab4d7c2614075e8R1-R101): Tests for the `psycopg_async_notify.publish` module.

These changes improve the maintainability and test coverage of the codebase, ensuring better reliability and easier future enhancements.